### PR TITLE
Fix AttributeError: 'tuple' object has no attribute 'decode'

### DIFF
--- a/imap_aex.py
+++ b/imap_aex.py
@@ -348,7 +348,11 @@ class ImapAttachmentExtractor:
             if self.inline_images:
                 reg_attachment = reg_attachment+"|image"
 
-            has_attachments = re.match('^.*"(%s)".*$' % reg_attachment, structure.decode("utf-8"), re.IGNORECASE) is not None
+            try:
+                has_attachments = re.match('^.*"(%s)".*$' % reg_attachment, structure.decode("utf-8"), re.IGNORECASE) is not None
+            except AttributeError as e:
+                print("Failed to process message. Error: %s" % e)
+                has_attachments = False
             if not has_attachments:
                 continue
 


### PR DESCRIPTION
Not sure, if it makes sense to process the tuple. At least it continues to processes all other messages.